### PR TITLE
Asynchronously run each provided task callback in order

### DIFF
--- a/henderson.js
+++ b/henderson.js
@@ -49,20 +49,21 @@
 
       var stateChange = after.length + pre.length;
 
-      return new Promise(function(resolve, reject) {
-        beforePost
-          .concat(post)
-          .reduce(function(series, task, index) {
-              if (index === stateChange)
-                fsm.current = next;
+      return beforePost
+        .concat(post)
+        .reduce(function(series, task, index) {
+          var args = getPrefix(index).concat(params);
+          return series.then(function() {
+            if (index === stateChange) {
+              fsm.current = next;
+            }
 
-              return series.then(task.apply(task, getPrefix(index).concat(params)))
-            }, Promise.resolve())
-          .then(function () {
-            fsm.current = next;
-            resolve();
+            return task.apply(task, args);
           });
-      });
+        }, Promise.resolve())
+        .then(function () {
+          fsm.current = next;
+        })
     }
 
     return fsm;

--- a/test/fsm.emitter.spec.js
+++ b/test/fsm.emitter.spec.js
@@ -26,49 +26,65 @@ describe('FSM event emitter', function() {
     });
   });
 
-  it('supports registering callbacks that will be fired when matching transitions occur', function() {
+  it('supports registering callbacks that will be fired when matching transitions occur', function(done) {
     var spy = sinon.spy();
 
     fsm.on('red', spy);
-    fsm.go('red');
-
-    spy.callCount.should.equal(1);
+    fsm.go('red')
+      .then(function () {
+        spy.callCount.should.equal(1);
+        done();
+      })
+      .catch(done);
   });
 
-  it('supports de-registering named callback functions', function() {
+  it('supports de-registering named callback functions', function(done) {
     var spy = sinon.spy();
 
     fsm.on('red', spy);
-    fsm.go('red');
-    fsm.unbind('red', spy);
-    fsm.go('red');
-
-    spy.callCount.should.equal(1);
+    fsm.go('red')
+      .then(function () {
+        fsm.unbind('red', spy);
+        return fsm.go('red');
+      })
+      .then(function () {
+        spy.callCount.should.equal(1);
+        done();
+      })
+      .catch(done);
   });
 
-  it('does not remove unrelated callbacks if unbind is called with a method not registered', function() {
+  it('does not remove unrelated callbacks if unbind is called with a method not registered', function(done) {
     var spy = sinon.spy();
 
     fsm.on('red', spy);
     fsm.unbind('red', function() {});
-    fsm.go('red');
-
-    spy.callCount.should.equal(1);
+    fsm.go('red')
+      .then(function () {
+        spy.callCount.should.equal(1);
+        done();
+      })
+      .catch(done);
   });
 
-  it('fires only callbacks matching the event', function() {
+  it('fires only callbacks matching the event', function(done) {
     var fst = sinon.spy();
     var snd = sinon.spy();
     fsm.on('red', fst);
     fsm.on('green', snd);
 
-    fsm.go('red');
-    fst.callCount.should.equal(1);
-    snd.called.should.equal(false);
-
-    fsm.go('green');
-    fst.callCount.should.equal(1);
-    snd.callCount.should.equal(1);
+    fsm.go('red')
+      .then(function () {
+        fst.callCount.should.equal(1);
+        snd.called.should.equal(false);
+        return fsm.go('green');
+      })
+      .then(function () {
+        fst.callCount.should.equal(1);
+        snd.callCount.should.equal(1);
+        done();
+      })
+      .catch(done);
   });
 
   it('supports registering any number of callbacks for a single event', function() {

--- a/test/fsm.transition.spec.js
+++ b/test/fsm.transition.spec.js
@@ -86,15 +86,25 @@ describe('FSM transitions', function() {
     fsm.go('red');
   });
 
-  it('fires the "all" event on every transition', function() {
+  it('fires the "all" event on every transition', function(done) {
     var spy = sinon.spy();
     var rnd = random(15);
+    var promises = [];
 
     fsm.on('*', spy);
     for (var i = 0; i < rnd; ++i) {
-      fsm.go( i % 2 ? 'green' : 'red' );
+      promises.push(function () {
+        return fsm.go(fsm.current === 'red' ? 'green' : 'red')
+      });
     }
 
-    spy.callCount.should.equal(rnd);
+    return promises.reduce(function(series, task) {
+      return series.then(task)
+    }, Promise.resolve())
+      .then(function () {
+        spy.callCount.should.equal(rnd);
+        done();
+      })
+      .catch(done);
   });
 });

--- a/test/readme_example_extensions.spec.js
+++ b/test/readme_example_extensions.spec.js
@@ -80,14 +80,19 @@ describe('Example extensions', function() {
       };
     });
 
-    it('fsm.once', function() {
+    it('fsm.once', function(done) {
       var spy = sinon.spy();
 
       fsm.once('red', spy);
-      fsm.go('red');
-      fsm.go('red');
-
-      spy.callCount.should.equal(1);
+      fsm.go('red')
+        .then(function () {
+          return fsm.go('red');
+        })
+        .then(function () {
+          spy.callCount.should.equal(1);
+          done();
+        })
+        .catch(done);
     });
   });
 


### PR DESCRIPTION
Before, each task callback would run at the same time, similar
to Promise.all. Now, it runs the callbacks in series. Each callback won't
run until the previous has finished.

This is a breaking change, but I think it's better. The library is much more powerful now: If a promise at the beginning of the list rejects, then the later callbacks won't even run. Good guarantees of things running in sequence.
